### PR TITLE
covarience matrix optimization

### DIFF
--- a/src/zalm.jl
+++ b/src/zalm.jl
@@ -58,7 +58,7 @@ _S35 = begin
         -1/sqrt(2)  0  1/sqrt(2)  0;
         0           0  0          1;
     ]
-    Matrix(BlockDiagonal([Id2, St35, Id2, Id2, St35, Id2]))
+    BlockDiagonal([Id2, St35, Id2, Id2, St35, Id2])
 end
 _S46 = begin
     Id2 = Matrix{Float64}(I, 2, 2)
@@ -68,9 +68,12 @@ _S46 = begin
         0  0           1  0;
         0  -1/sqrt(2)  0  1/sqrt(2);
     ]
-    Matrix(BlockDiagonal([Id2, St46, Id2, Id2, St46, Id2]))
+    BlockDiagonal([Id2, St46, Id2, Id2, St46, Id2])
 end
 
+# Precompute constant matrix products
+const _S35_S46_PRODUCT = Matrix(_S46 * _S35)
+const _S35_ADJOINT_S46_ADJOINT = Matrix(_S35' * _S46')
 """
     covariance_matrix(μ::Real)
 
@@ -89,7 +92,7 @@ function covariance_matrix(μ::Real)
 
     # Reorder qpqp → qqpp and apply beamsplitters
     covar_qqpp = reorder(covar_qpqp) 
-    return _S46 * _S35 * covar_qqpp * _S35' * _S46'
+    return _S35_S46_PRODUCT * covar_qqpp * _S35_ADJOINT_S46_ADJOINT
 end
 covariance_matrix(zalm::ZALM) = covariance_matrix(zalm.mean_photon)
 

--- a/test/bench_compare.jl
+++ b/test/bench_compare.jl
@@ -1,0 +1,128 @@
+using Genqo
+using BenchmarkTools
+using Nemo
+using LinearAlgebra
+using BlockDiagonals
+
+
+suite = BenchmarkGroup()
+
+uniform(min_val, max_val) = min_val + (max_val-min_val)*rand(Float64)
+log_uniform(min_exp, max_exp) = 10^uniform(min_exp, max_exp)
+
+rand_sigsag() = sigsag.SIGSAG(
+    log_uniform(-5, 1),
+    uniform(0.5, 1.0),
+    uniform(0.5, 1.0),
+    uniform(0.5, 1.0),
+)
+
+# Global canonical position and momentum variables
+const mds = 6 # Number of modes for our system
+
+_qai = ["qa$i" for i in 1:mds]
+_pai = ["pa$i" for i in 1:mds]
+_qbi = ["qb$i" for i in 1:mds]
+_pbi = ["pb$i" for i in 1:mds]
+all_qps = hcat(_qai, _pai, _qbi, _pbi)
+CC = ComplexField()
+i = onei(CC) # Imaginary unit in CC ring
+R, generators = polynomial_ring(CC, all_qps)
+(qai, pai, qbi, pbi) = (generators[:,i] for i in 1:4)
+
+# Define the alpha and beta vectors
+α = (qai + i .* pai) / sqrt(2)
+β = (qbi - i .* pbi) / sqrt(2)
+
+function probability_success_new(μ::Real, ηᵗ::Real, ηᵈ::Real)
+    cov = sigsag.covariance_matrix(μ)
+    A = tools.k_function_matrix(cov) + sigsag.loss_bsm_matrix_pgen(ηᵗ, ηᵈ)
+    lu!(A)
+    Ainv = inv(A)
+    Γ = cov + (1/2)*I
+    detΓ = det(Γ)
+
+    D1 = sqrt(det(A))
+    D2 = detΓ^(1/4)
+    D3 = conj(detΓ)^(1/4)
+    Coef = 1/(D1*D2*D3)
+
+    C = ηᵈ^2 * (α[1]*α[2]) * (β[1]*β[2]) # moment_vector([0,0,0,0], [0,0,0,0], ηᵗ, ηᵈ)
+
+    return real(Coef * tools.W(C, Ainv))
+end
+probability_success_new(sigsag::sigsag.SIGSAG) = probability_success_new(sigsag.mean_photon, sigsag.outcoupling_efficiency, sigsag.detection_efficiency)
+
+
+# suite["sigsag.probability_success_old"] = @benchmarkable sigsag.probability_success(s) setup=(s=rand_sigsag())
+# suite["sigsag.probability_success_new"] = @benchmarkable probability_success_new(s) setup=(s=rand_sigsag())
+
+#probability of sucess zalm
+ 
+rand_zalm() = zalm.ZALM(
+    log_uniform(-5, 1),
+    #[one(Float64)],
+    uniform(0.5, 1.0),
+    uniform(0.5, 1.0),
+    uniform(0.5, 1.0),
+    zero(Float64),
+    #one(Float64)
+)
+nvec = [1,0,1,1,0,0,1,0]
+
+#Not sucessful
+function zalm_probability_success_new(μ::Real, ηᵗ::Real, ηᵈ::Real, ηᵇ::Real, dark_counts::Real)
+    cov = zalm.covariance_matrix(μ)
+    A = zalm.k_function_matrix(cov) + zalm.loss_bsm_matrix_pgen(ηᵗ, ηᵈ, ηᵇ)
+    lu!(A)
+    Ainv = inv(A)
+    Γ = cov + (1/2)*I
+    detΓ = det(Γ)
+
+    D1 = sqrt(det(A))
+    D2 = detΓ^(1/4)
+    D3 = conj(detΓ)^(1/4)
+    Coef = 1/(D1*D2*D3)
+
+    # TODO: should this indexing be changed to 1-based? Or is there some mathematical meaning to the 0 index?
+    C1 = zalm.moment_terms[0]
+    C2 = zalm.moment_terms[9]
+    C3 = zalm.moment_terms[10]
+    C4 = zalm.moment_terms[14]
+
+    return real(Coef * (
+        ηᵇ^2 * (1-dark_counts)^4 * zalm.W(C1, Ainv) +
+        ηᵇ * dark_counts * (1-dark_counts)^3 * zalm.W(C2, Ainv) +
+        ηᵇ * dark_counts * (1-dark_counts)^3 * zalm.W(C3, Ainv) +
+        dark_counts^2 * (1-dark_counts)^2 * zalm.W(C4, Ainv)
+    ))
+end
+ zalm_probability_success_new(zalm::zalm.ZALM) =  zalm_probability_success_new(zalm.mean_photon, zalm.outcoupling_efficiency, zalm.detection_efficiency, zalm.bsm_efficiency, zalm.dark_counts)
+
+
+# suite["zalm.probability_success_old"]    = @benchmarkable zalm.probability_success(z)         setup=(z=rand_zalm())
+# suite["zalm.probability_success_new"]    = @benchmarkable  zalm_probability_success_new(z)         setup=(z=rand_zalm())
+
+#Not consistent
+function zalm_covariance_matrix_old(μ::Real)
+   # Initial ZALM covariance matrix in qpqp ordering
+    spdc_covar = spdc.covariance_matrix(μ)
+    covar_qpqp = Matrix(BlockDiagonal([spdc_covar, spdc_covar]))
+
+    # Reorder qpqp → qqpp and apply beamsplitters
+    covar_qqpp = tools.reorder(covar_qpqp) 
+
+    return zalm._S46 * zalm._S35 * covar_qqpp * zalm._S35' * zalm._S46' # or similar pattern
+end
+zalm_covariance_matrix_old(zalm::zalm.ZALM) = zalm_covariance_matrix_old(zalm.mean_photon)
+
+suite["zalm.covariance_matrix_new"]      = @benchmarkable zalm.covariance_matrix(z)           setup=(z=rand_zalm())
+suite["zalm.covariance_matrix_old"]      = @benchmarkable zalm_covariance_matrix_old(z)           setup=(z=rand_zalm())
+
+results = run(suite)
+for (func, trial) in results
+    println("$func:")
+    display(trial)
+    println()
+end
+ 


### PR DESCRIPTION
Main changes to Covarience_matrix in Zalm by computing the matrix multiplications of _S35_S46  and its adjoint at the module level, although it seems like this betters the functions performance but the results are not consistent and probably comes at the cost of making the module slower. And added a benchmark comparison in the test/bench_compare and there are other attempts to optimize other functions that were unsuccessful. I made the new changes inside Genqo to facilitate running tests and in bench_compare is the old function. 

from doing profiling on probability generation and fidelity. The biggest bottle necks are loss_bsm_matrix_pgen specifically the + and / operators of matrices. and the w function, specifically wick_out() because of the use of nested for loops and the * operator. But I am really not sure how to optimize those functions.